### PR TITLE
Port over installation instructions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -240,6 +240,7 @@ lazy val website = project
     preprocess in Preprocess := (preprocess in Preprocess).dependsOn(tut).value,
     preprocessVars in Preprocess := Map(
       "VERSION" -> version.value,
+      "STABLE_VERSION" -> "1.5.1",
       "SCALAMETA_VERSION" -> scalametaV
     )
   )

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,244 @@
+---
+id: installation
+title: Installation
+---
+
+## CLI
+
+The recommended way to install the scalafmt command line tool is with
+[Coursier](#Coursier).
+
+### Coursier
+
+**NOTE** To install Coursier see [here](https://github.com/coursier/coursier#command-line).
+
+Create a standalone executable in `/usr/local/bin/scalafmt` with (sudo if necessary):
+
+```sh
+coursier bootstrap com.geirsson:scalafmt-cli_2.12:@VERSION@ \
+  -r bintray:scalameta/maven \
+  -o /usr/local/bin/scalafmt --standalone --main org.scalafmt.cli.Cli
+scalafmt --version # should be @VERSION@
+```
+
+Alternatively you can create a slim 15 KiB bootstrap script with:
+
+```sh
+coursier bootstrap com.geirsson:scalafmt-cli_2.12:@VERSION@ \
+  -r bintray:scalameta/maven \
+  -o scalafmt --main org.scalafmt.cli.Cli
+./scalafmt --version # should be @VERSION@
+```
+
+It is **recommended** to put this bootstrap script in your code repository to make sure
+everyone on your team, as well as CI, uses the same scalafmt version. To
+configure which files to format, see [project](#project).
+
+To customize the JVM options, use the Coursier option `--java-opt`, more info
+with
+
+```sh
+coursier bootstrap --help | grep -A 1 "\-\-java-opt"
+```
+
+### Pre-release
+
+Our CI publishes a pre-release version of scalafmt to Bintray on every merge
+into master. To use a pre-release, replace @VERSION@ with the version here:
+
+<a href='https://bintray.com/scalameta/maven/scalafmt-cli/_latestVersion'>
+    <img src='https://api.bintray.com/packages/scalameta/maven/scalafmt-cli/images/download.svg'>
+</a>
+
+If you use coursier to install a pre-release, be sure to include the flag -r
+bintray:scalameta/maven so that the artifact can be resolved.
+
+If you use sbt to install a pre-release, be sure to add the following setting
+
+```scala
+resolvers += Resolver.bintray("scalameta", "maven")
+```
+
+### Nailgun
+
+Nailgun is recommended if you want to integrate scalafmt with a text editor like
+vim/Emacs/Atom/Sublime/VS Code.
+
+- Make sure you have a nailgun client installed. For example with `brew install nailgun`.
+- Create a standalone executable in `/usr/local/bin/scalafmt_ng` with (sudo if necessary)
+
+```sh
+coursier bootstrap --standalone com.geirsson:scalafmt-cli_2.12:@VERSION@ \
+  -r bintray:scalameta/maven \
+  -o /usr/local/bin/scalafmt_ng -f --main com.martiansoftware.nailgun.NGServer
+scalafmt_ng & // start nailgun in background
+ng ng-alias scalafmt org.scalafmt.cli.Cli
+ng scalafmt --version # should be @VERSION@
+```
+
+Nailgun keeps scalafmt running on a local server to avoid the JVM startup
+penalty and also so scalafmt can benefit from JIT. This makes scalafmt up to 10x
+faster when formatting a single file from the CLI. The downside to Nailgun is
+that the setup is complicated and the long-running server needs to be restarted
+once in awhile.
+
+### Homebrew
+
+You can install scalafmt via Homebrew using a custom formula
+
+```sh
+brew install --HEAD olafurpg/scalafmt/scalafmt
+scalafmt --version // should be @VERSION@
+
+// to upgrade between releases
+brew upgrade scalafmt
+```
+
+### --help
+
+```tut
+org.scalafmt.cli.CliArgParser.buildInfo
+```
+
+```tut
+org.scalafmt.cli.CliArgParser.scoptParser.usage
+```
+
+## IntelliJ
+
+TODO
+
+## sbt
+
+You can choose between
+
+- [sbt-scalafmt](#sbt-scalafmt) (sbt 1.0 only)
+- [neo-sbt-scalafmt](#neo-sbt-scalafmt) (sbt 0.13 and sbt 1.0)
+
+### sbt-scalafmt
+
+```scala
+// In project/plugins.sbt. Note, does not support sbt 0.13, only sbt 1.0.
+addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
+```
+
+The sbt plugin is enabled by default for the Test and Compile configurations. To
+enable the plugin for integration tests
+
+```scala
+inConfig(IntegrationTest)(scalafmtConfigSettings)
+```
+
+and then use `it:scalafmt` to format.
+
+Pro tip. To share configuration across projects, you can define a setting in
+`build.sbt` to generate `.scalafmt.conf` programmatically on sbt load.
+
+```scala
+// define setting key to write configuration to .scalafmt.conf
+SettingKey[Unit]("scalafmtGenerateConfig") :=
+  IO.write( // writes to file once when build is loaded
+    file(".scalafmt.conf"),
+    """style = IntelliJ
+      |# Your configuration here
+      """.stripMargin.getBytes("UTF-8")
+  )
+```
+
+### neo-sbt-scalafmt
+
+[lucidsoftware/neo-sbt-scalafmt](https://github.com/lucidsoftware/neo-sbt-scalafmt)
+is an sbt plugin that
+
+- supports both sbt 0.13 and 1.0.0
+- supports any version of scalafmt
+- runs in-process
+- uses SBT's update resolutions mechanism, which tends to be slow for large
+  multi-module builds.
+
+## Gradle
+
+It is possible to use scalafmt in gradle with the following externally
+maintained plugins:
+
+- [Spotless](https://github.com/diffplug/spotless/tree/master/plugin-gradle#applying-scalafmt-to-scala-files)
+- [gradle-scalafmt](https://github.com/alenkacz/gradle-scalafmt)
+
+## Maven
+
+It is possible to use scalafmt in Maven with the following externally maintained
+plugin:
+
+- [mvn_scalafmt](https://github.com/SimonJPegg/mvn_scalafmt)
+
+## Mill
+
+Mill have scalafmt support built-in:
+
+- [scalafmt module](http://www.lihaoyi.com/mill/page/configuring-mill.html#reformatting-your-code)
+
+## Vim
+
+- Make sure you have the [CLI](#CLI) installed and working.
+- install [vim-autoformat](https://github.com/Chiel92/vim-autoformat)
+- add to your `.vimrc`
+
+```
+noremap <F5> :Autoformat<CR>
+let g:formatdef_scalafmt = "'scalafmt --stdin'"
+let g:formatters_scala = ['scalafmt']
+```
+
+**NOTE**. You pay the JVM startup penalty on every format unless you're using
+[Nailgun](#nailgun).
+
+## Standalone library
+
+Add to your dependencies
+
+```scala
+libraryDependencies += "com.geirsson" %% "scalafmt-core" % "@VERSION@"
+// Scala.js
+libraryDependencies += "com.geirsson" %%% "scalafmt-core" % "@VERSION@"
+```
+
+Use the API like this:
+
+```tut
+org.scalafmt.Scalafmt.format("""
+      object FormatMe { List(Split(Space, 0).withPolicy(SingleLineBlock(close)), Split(Newline, 1).withPolicy{ case Decision(t@FormatToken(_, `close`, _), s) => Decision(t, List(Split(Newline, 0)))}.withIndent(2, close, Right)) }
+""").get
+```
+
+Obtain a configuration object with `parseHoconConfig`
+
+```tut
+val config = org.scalafmt.Scalafmt.parseHoconConfig("align=most").get
+org.scalafmt.Scalafmt.format("""
+    object Align {
+        val x = 1
+        val xx = 2
+    }
+""", config).get
+```
+
+To format code with top-level statements like `*.sbt` files
+
+```tut
+val base = org.scalafmt.Scalafmt.parseHoconConfig("align=most").get
+val config = org.scalafmt.Scalafmt.configForSbt(base)
+org.scalafmt.Scalafmt.format("""
+    val x = 1
+    val xx = 2
+""", config).get
+```
+
+The Scalafmt public API consists only of methods in`org.scalafmt.Scalafmt`. In
+particular, case classes in `org.scalafmt.config` are subject to binary and
+source breaking changes on any release.
+
+## Help Wanted
+
+- Ensime
+- Scala IDE ([help wanted!](https://github.com/scalameta/scalafmt/issues/125))
+- Your favorite editor? Join the gitter channel.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -106,7 +106,33 @@ println(website.plaintext(org.scalafmt.cli.CliArgParser.scoptParser.usage))
 
 ## IntelliJ
 
-TODO
+<div class="sidenote">
+  Please upvote <a href="https://youtrack.jetbrains.com/issue/SCL-13658">this Jetbrains ticket</a>
+  about adding built-in support for Scalafmt in the IntelliJ Scala plugin.
+</div>
+
+[Here is the plugin](https://plugins.jetbrains.com/plugin/8236?pr=). You can
+install it directly from within IntelliJ:
+
+- open `Settings > Plugins`
+- open `Browse repositories`
+- search for `scalafmt`
+- restart IntelliJ.
+
+The default shortcut is `Ctrl + Shift + L`. Undo works, but not redo.
+
+The plugin determines which style to use in this order:
+
+1. `.scalafmt.conf` in the project's root directory, if it exists
+1. `$HOME/.scalafmt.conf`, if it exists
+1. Otherwise, uses `default` style.
+
+For details on how `.scalafmt.conf` should look like, see
+[Configuration](configuration.md). The scalafmt IntelliJ
+plugin has a "Format on save" setting.
+
+- To enable for current project: `Settings > Tools > Scalafmt`
+- To enable for all future project: `File > Other settings > Default settings > Scalafmt`
 
 ## sbt
 
@@ -242,3 +268,5 @@ source breaking changes on any release.
 - Ensime
 - Scala IDE ([help wanted!](https://github.com/scalameta/scalafmt/issues/125))
 - Your favorite editor? Join the gitter channel.
+
+[intellij-ticket]: https://youtrack.jetbrains.com/issue/SCL-13658

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,7 +10,9 @@ The recommended way to install the scalafmt command line tool is with
 
 ### Coursier
 
-**NOTE** To install Coursier see [here](https://github.com/coursier/coursier#command-line).
+<div class="sidenote">
+To install Coursier see <a href="https://github.com/coursier/coursier#command-line" target="_blank">here</a>
+</div>
 
 Create a standalone executable in `/usr/local/bin/scalafmt` with (sudo if necessary):
 
@@ -215,8 +217,10 @@ let g:formatdef_scalafmt = "'scalafmt --stdin'"
 let g:formatters_scala = ['scalafmt']
 ```
 
-**NOTE**. You pay the JVM startup penalty on every format unless you're using
-[Nailgun](#nailgun).
+<div class="sidenote">
+You pay the JVM startup penalty on every format unless you're using
+<a href="#nailgun">Nailgun</a>.
+</div>
 
 ## Standalone library
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -96,12 +96,12 @@ brew upgrade scalafmt
 
 ### --help
 
-```tut
-org.scalafmt.cli.CliArgParser.buildInfo
+```tut:passthrough
+println(website.plaintext(org.scalafmt.cli.CliArgParser.buildInfo))
 ```
 
-```tut
-org.scalafmt.cli.CliArgParser.scoptParser.usage
+```tut:passthrough
+println(website.plaintext(org.scalafmt.cli.CliArgParser.scoptParser.usage))
 ```
 
 ## IntelliJ

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,19 +15,19 @@ The recommended way to install the scalafmt command line tool is with
 Create a standalone executable in `/usr/local/bin/scalafmt` with (sudo if necessary):
 
 ```sh
-coursier bootstrap com.geirsson:scalafmt-cli_2.12:@VERSION@ \
+coursier bootstrap com.geirsson:scalafmt-cli_2.12:@STABLE_VERSION@ \
   -r bintray:scalameta/maven \
   -o /usr/local/bin/scalafmt --standalone --main org.scalafmt.cli.Cli
-scalafmt --version # should be @VERSION@
+scalafmt --version # should be @STABLE_VERSION@
 ```
 
 Alternatively you can create a slim 15 KiB bootstrap script with:
 
 ```sh
-coursier bootstrap com.geirsson:scalafmt-cli_2.12:@VERSION@ \
+coursier bootstrap com.geirsson:scalafmt-cli_2.12:@STABLE_VERSION@ \
   -r bintray:scalameta/maven \
   -o scalafmt --main org.scalafmt.cli.Cli
-./scalafmt --version # should be @VERSION@
+./scalafmt --version # should be @STABLE_VERSION@
 ```
 
 It is **recommended** to put this bootstrap script in your code repository to make sure
@@ -44,7 +44,7 @@ coursier bootstrap --help | grep -A 1 "\-\-java-opt"
 ### Pre-release
 
 Our CI publishes a pre-release version of scalafmt to Bintray on every merge
-into master. To use a pre-release, replace @VERSION@ with the version here:
+into master. To use a pre-release, replace @STABLE_VERSION@ with the version here:
 
 <a href='https://bintray.com/scalameta/maven/scalafmt-cli/_latestVersion'>
     <img src='https://api.bintray.com/packages/scalameta/maven/scalafmt-cli/images/download.svg'>
@@ -68,12 +68,12 @@ vim/Emacs/Atom/Sublime/VS Code.
 - Create a standalone executable in `/usr/local/bin/scalafmt_ng` with (sudo if necessary)
 
 ```sh
-coursier bootstrap --standalone com.geirsson:scalafmt-cli_2.12:@VERSION@ \
+coursier bootstrap --standalone com.geirsson:scalafmt-cli_2.12:@STABLE_VERSION@ \
   -r bintray:scalameta/maven \
   -o /usr/local/bin/scalafmt_ng -f --main com.martiansoftware.nailgun.NGServer
 scalafmt_ng & // start nailgun in background
 ng ng-alias scalafmt org.scalafmt.cli.Cli
-ng scalafmt --version # should be @VERSION@
+ng scalafmt --version # should be @STABLE_VERSION@
 ```
 
 Nailgun keeps scalafmt running on a local server to avoid the JVM startup
@@ -88,7 +88,7 @@ You can install scalafmt via Homebrew using a custom formula
 
 ```sh
 brew install --HEAD olafurpg/scalafmt/scalafmt
-scalafmt --version // should be @VERSION@
+scalafmt --version // should be @STABLE_VERSION@
 
 // to upgrade between releases
 brew upgrade scalafmt
@@ -197,9 +197,9 @@ let g:formatters_scala = ['scalafmt']
 Add to your dependencies
 
 ```scala
-libraryDependencies += "com.geirsson" %% "scalafmt-core" % "@VERSION@"
+libraryDependencies += "com.geirsson" %% "scalafmt-core" % "@STABLE_VERSION@"
 // Scala.js
-libraryDependencies += "com.geirsson" %%% "scalafmt-core" % "@VERSION@"
+libraryDependencies += "com.geirsson" %%% "scalafmt-core" % "@STABLE_VERSION@"
 ```
 
 Use the API like this:

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -9,6 +9,7 @@
     "contributing-website": "Contributing to the website",
     "faq": "FAQ / Troubleshooting",
     "gotchas": "Gotchas",
+    "installation": "Installation",
     "introduction": "Introduction",
     "known-issues": "Known Issues",
     "Docs": "Docs",

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -2,6 +2,7 @@
   "docs": {
     "Documentation": [
       "introduction",
+      "installation",
       "configuration",
       "gotchas",
       "faq",

--- a/website/src/main/scala/website/package.scala
+++ b/website/src/main/scala/website/package.scala
@@ -7,6 +7,11 @@ import scala.meta.Dialect
 
 package object website {
 
+  def plaintext(code: String): String =
+    s"""|```
+        |$code
+        |```""".stripMargin
+
   private[this] def scalaCode(code: String): String =
     s"""|```scala
         |$code

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -51,38 +51,49 @@ pre {
     content: "// After";
 }
 
+.sidenote {
+    margin: 1em 0;
+    color: #0c5460;
+    background-color: #d1ecf1;
+    border-left: 10px solid #bee5eb;
+    padding: .75rem 1.25rem;
+}
+
+.sidenote a {
+    color: #37a;
+}
+
+/* Helper classes to toggling content for specific devices */
+.widescreen-only {
+    display: none;
+}
+
+.non-widescreen-only {
+    display: none;
+}
+
 @media only screen and (min-device-width: 360px) and (max-device-width: 736px) {}
 
 @media only screen and (min-width: 1024px) {}
 
 @media only screen and (max-width: 1023px) {}
 
+/* Widescreen */
 @media only screen and (min-width: 1400px) {
     .scalafmt-pair {
         flex-direction: row;
     }
-}
 
-@media only screen and (min-width: 1500px) {}
-
-/* Helper classes to toggling content for specific devices */
-
-span.widescreen-only {
-    display: none;
-}
-
-span.non-widescreen-only {
-    display: none;
-}
-
-@media only screen and (min-width: 1400px) {
     span.widescreen-only {
         display: inline;
     }
 }
 
+/* Non-widescreen */
 @media only screen and (max-width: 1400px) {
     span.non-widescreen-only {
         display: inline;
     }
 }
+
+@media only screen and (min-width: 1500px) {}


### PR DESCRIPTION
There are a few caveats:

I used @VERSION@ all the places where 1.5.1 was mentioned on the site.
On my branch that's currently 1.6.0-RC1-14-b09fd59a. I don't know
if we need to distinguish between the current version and the stable
version

The --help section is a bit funny as it's shown as a REPL session now
and therefore some of the text is truncated. I haven't used tut before,
is there a better way to do this?

I haven't ported the intellij section over as I believe it's now built
in?